### PR TITLE
merge origin/master

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4058,12 +4058,14 @@ write_files:
                     - --stderrthreshold=info
                     - --cloud-provider=aws
                     - --skip-nodes-with-local-storage=false
+                    - --skip-nodes-with-system-pods=false
                     - --expander=least-waste
                     - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,kubernetes.io/cluster/{{.ClusterName}}
                   env:
                     - name: AWS_REGION
                       value: {{.Region}}
                   imagePullPolicy: "Always"
+              dnsPolicy: Default
   {{end}}
 
   - path: /srv/kubernetes/manifests/heapster-svc.yaml


### PR DESCRIPTION
* autoscaler: update cloud-config-controller

modifies the behavior of the autoscaler to terminate worker and
controller nodes no longer needed when minSize is set manually.

Note that I had to delete the initial autoscaler pod after
deploying a new cluster with this modification in place.
After that initial autoscaler pod was deleted the second
pod functioned without errors and as expected.
I will update the issue comments with more details.

Fixes #1253

* update CA in cloud-config-controller with dnsPolicy: Default